### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyttsx/drivers/dummy.py
+++ b/pyttsx/drivers/dummy.py
@@ -92,7 +92,7 @@ class DummyDriver(object):
         '''
         Stops a previously started run loop.
 
-        @precondition: A previous call to L{startLoop} suceeded and there was
+        @precondition: A previous call to L{startLoop} succeeded and there was
             no intervening call to L{endLoop}.
         '''
         self._looping = False
@@ -151,7 +151,7 @@ class DummyDriver(object):
 
     def getProperty(self, name):
         '''
-        Gets a property value of the speech engine. The suppoted properties
+        Gets a property value of the speech engine. The supported properties
         and their values are:
 
         voices: List of L{voice.Voice} objects supported by the driver


### PR DESCRIPTION
There are small typos in:
- pyttsx/drivers/dummy.py

Fixes:
- Should read `supported` rather than `suppoted`.
- Should read `succeeded` rather than `suceeded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md